### PR TITLE
MSSCI-6346 move public cicd jobs to private runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     timeout-minutes: 360
     permissions:
       actions: read
@@ -53,7 +53,7 @@ jobs:
 
   lint-golangci:
     name: "GolangCI Lint"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     if: github.event_name == 'pull_request'
     permissions:
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -32,7 +32,7 @@ jobs:
   docs:
     name: Docs Test
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     concurrency:
       group: test-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Why
- Resource Consumption: Public runners share a fixed pool of minutes, which can lead to unnecessary expenses and recommendations to purchase more.
- Security Risks: Running jobs on public runners increases the risk of exposing secrets to third-party servers.
- Inconsistent Performance: Public runners offer varying network reachability and performance, making it hard to accurately measure job resource usage.
- Operational Clarity: Private runners provide better visibility into job performance and resource requirements, helping us optimize our CI/CD processes. We have Datadog agents on our runners and the kubernetes cluster they run on, we have no such monitoring of public runners.

## What

This PR moves all CI/CD jobs from public to private runners by updating our GitHub Actions workflows:
It replaces “runs-on: ubuntu-latest” with “runs-on: [self-hosted, Ubuntu, Common]”.

Future Consideration:
We will introduce different runner classes for jobs with high resource needs to further refine our performance monitoring and resource allocation.