### PR TITLE
fix: autobuild mode for codeql pipelines

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,6 @@ jobs:
       matrix:
         include:
           - language: go
-            build-mode: autobuild
             dependency-caching: true
 
     steps:
@@ -38,10 +37,12 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
+          #
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality


### PR DESCRIPTION
## what

- Fix the autobuild mode for CodeQL pipelines to correctly scan and output findings from our Go linters

## why

- Resolve the following error:

```console
Go files were found but not processed (1 result)
    * [Specify a custom build command](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-the-codeql-workflow-for-compiled-languages)
    *  that includes one or more `go build` commands to build the `.go` files to be analyzed.
```

## references

- [Confusing Error](https://github.com/github/codeql-action/issues/2515)
- [Atmos Reference](https://github.com/cloudposse/atmos/blob/main/.github/workflows/codeql.yml)
- [CodeQL Docs](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages)
