### PR TITLE
chore: add test sweepers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,14 +83,27 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: "3.x"
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go mod download
-      - env:
+      - name: Run Acceptance Tests
+        env:
           TF_ACC: "1"
           ARMIS_API_URL: ${{ secrets.ARMIS_API_URL }}
           ARMIS_API_KEY: ${{ secrets.ARMIS_API_KEY }}
         run: go test -v ./internal/provider/
         timeout-minutes: 10
+      - name: Cleanup Dangling Resources
+        env:
+          TF_ACC: "1"
+          ARMIS_API_URL: ${{ secrets.ARMIS_API_URL }}
+          ARMIS_API_KEY: ${{ secrets.ARMIS_API_KEY }}
+        run: task sweep
+        timeout-minutes: 5

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -94,6 +94,11 @@ tasks:
     cmds:
       - rm -f "$HOME/.terraformrc"
 
+  sweep:
+    desc: "Run sweeper tests to clean up resources. WARNING: This will destroy resources! Use with caution."
+    cmds:
+      - go test ./internal/provider -v -timeout 5m -sweep=lab
+
   prep:
     desc: "Prepare the provider"
     deps:

--- a/internal/armis/errors.go
+++ b/internal/armis/errors.go
@@ -9,6 +9,7 @@ import "errors"
 
 var (
 	ErrGetKey       = errors.New("failed to get API key")
+	ErrGetURL       = errors.New("failed to get API URL")
 	ErrNoAPIKey     = errors.New("missing API key")
 	ErrAuthFailed   = errors.New("failed to authenticate")
 	ErrHTTPResponse = errors.New("HTTP response error")

--- a/internal/provider/armis_sweeper_test.go
+++ b/internal/provider/armis_sweeper_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 1898 & Co.
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/1898andCo/terraform-provider-armis-centrix/internal/sweep"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestMain is responsible for parsing the special test flags and invoking the sweepers
+//
+//	See: https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests/sweepers
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func init() {
+	resource.AddTestSweepers("collectors", sweep.SweepArmisCollectors("collectors"))
+	resource.AddTestSweepers("users", sweep.SweepArmisUsers("users"))
+	resource.AddTestSweepers("roles", sweep.SweepArmisRoles("roles"))
+}

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -18,7 +18,7 @@ func TestAcc_RoleResource(t *testing.T) {
 			{
 				Config: testAccRoleResourceConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "test-role"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test"),
 
 					resource.TestCheckResourceAttr(resourceName, "permissions.advanced_permissions.all", "false"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.advanced_permissions.behavioral.all", "false"),
@@ -72,7 +72,7 @@ func TestAcc_RoleResource(t *testing.T) {
 func testAccRoleResourceConfig() string {
 	return `
 resource "armis_role" "test" {
-  name = "test-role"
+  name = "test"
 
   permissions = {
     advanced_permissions = {

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -18,7 +18,7 @@ func TestAcc_UserResource(t *testing.T) {
 			{
 				Config: testAccUserResourceConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "Test User"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test"),
 					resource.TestCheckResourceAttr(resourceName, "phone", "8675309"),
 					resource.TestCheckResourceAttr(resourceName, "location", "Houston"),
 					resource.TestCheckResourceAttr(resourceName, "username", "test.user@test.com"),
@@ -34,7 +34,7 @@ func TestAcc_UserResource(t *testing.T) {
 func testAccUserResourceConfig() string {
 	return `
 resource "armis_user" "test" {
-  name = "Test User"
+  name = "test"
 
   phone    = "8675309"
   location = "Houston"

--- a/internal/sweep/collector_resource_test_sweeper.go
+++ b/internal/sweep/collector_resource_test_sweeper.go
@@ -1,0 +1,50 @@
+// Copyright (c) 1898 & Co.
+// SPDX-License-Identifier: Apache-2.0
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// SweepArmisCollectors returns a sweeper function to clean up Armis collectors.
+func SweepArmisCollectors(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(_ string) error {
+			client, err := ConfigureSweeperClient(name)
+			if err != nil {
+				return fmt.Errorf("error configuring Armis client: %w", err)
+			}
+			if client == nil {
+				return nil
+			}
+
+			// Get all collectors
+			ctx := context.Background()
+			collectors, err := client.GetCollectors(ctx)
+			if err != nil {
+				return fmt.Errorf("error getting Armis collectors: %w", err)
+			}
+
+			prefix := "test."
+			for _, collector := range collectors {
+				if strings.HasPrefix(collector.Name, prefix) {
+					log.Printf("[INFO] Deleting Armis collector: %s", collector.Name)
+					_, err := client.DeleteCollector(ctx, strconv.Itoa(collector.CollectorNumber))
+					if err != nil {
+						log.Printf("[ERROR] Failed to delete Armis collector %s: %s", collector.Name, err)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/sweep/role_resource_test_sweeper.go
+++ b/internal/sweep/role_resource_test_sweeper.go
@@ -1,0 +1,49 @@
+// Copyright (c) 1898 & Co.
+// SPDX-License-Identifier: Apache-2.0
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// SweepArmisRoles will delete all Armis roles with names starting with "test".
+func SweepArmisRoles(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(_ string) error {
+			client, err := ConfigureSweeperClient(name)
+			if err != nil {
+				return fmt.Errorf("error configuring Armis client: %w", err)
+			}
+			if client == nil {
+				return nil
+			}
+
+			ctx := context.Background()
+			roles, err := client.GetRoles(ctx)
+			if err != nil {
+				return fmt.Errorf("error listing Armis roles: %w", err)
+			}
+
+			prefix := "test"
+			for _, role := range roles {
+				if strings.HasPrefix(role.Name, prefix) {
+					log.Printf("[INFO] Deleting Armis role: %s", role.Name)
+					_, err := client.DeleteRole(ctx, strconv.Itoa(role.ID))
+					if err != nil {
+						log.Printf("[ERROR] Failed to delete Armis role %s: %s", role.Name, err)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/sweep/sweeper_utils.go
+++ b/internal/sweep/sweeper_utils.go
@@ -1,0 +1,42 @@
+// Copyright (c) 1898 & Co.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package sweep provides utility functions for configuring and running
+// test sweepers for Armis resources in Terraform.
+package sweep
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/1898andCo/terraform-provider-armis-centrix/internal/armis"
+)
+
+// ConfigureSweeperClient initializes an Armis client using environment variables
+// It returns the client and an error if initialization fails.
+func ConfigureSweeperClient(name string) (*armis.Client, error) {
+	// Get configuration from environment variables
+	apiKey := os.Getenv("ARMIS_API_KEY")
+	if apiKey == "" {
+		log.Printf("[INFO] Skipping %s sweeper - ARMIS_API_KEY not set", name)
+		return nil, armis.ErrGetKey
+	}
+
+	apiURL := os.Getenv("ARMIS_API_URL")
+	if apiURL == "" {
+		log.Printf("[INFO] Skipping %s sweeper - ARMIS_API_URL not set", name)
+		return nil, armis.ErrGetURL
+	}
+
+	// Initialize the client
+	client, err := armis.NewClient(
+		apiKey,
+		armis.WithAPIURL(apiURL),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Armis client: %w", err)
+	}
+
+	return client, nil
+}

--- a/internal/sweep/user_resource_test_sweeper.go
+++ b/internal/sweep/user_resource_test_sweeper.go
@@ -1,0 +1,50 @@
+// Copyright (c) 1898 & Co.
+// SPDX-License-Identifier: Apache-2.0
+
+package sweep
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// SweepArmisUsers will delete all Armis users with users starting with "test".
+func SweepArmisUsers(name string) *resource.Sweeper {
+	return &resource.Sweeper{
+		Name: name,
+		F: func(_ string) error {
+			client, err := ConfigureSweeperClient(name)
+			if err != nil {
+				return fmt.Errorf("error configuring Armis client: %w", err)
+			}
+			if client == nil {
+				return nil
+			}
+
+			// Get all users
+			ctx := context.Background()
+			users, err := client.GetUsers(ctx)
+			if err != nil {
+				return fmt.Errorf("error getting Armis users: %w", err)
+			}
+
+			prefix := "test."
+			for _, user := range users {
+				if strings.HasPrefix(user.Username, prefix) {
+					log.Printf("[INFO] Deleting Armis user: %s", user.Username)
+					_, err := client.DeleteUser(ctx, strconv.Itoa(user.ID))
+					if err != nil {
+						log.Printf("[ERROR] Failed to delete Armis user %s: %s", user.Username, err)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## what

* Added new sweeper utility functions for collectors, users, and roles in the `internal/sweep` package, which delete resources with names/usernames starting with "test". (`internal/sweep/collector_resource_test_sweeper.go`, `internal/sweep/user_resource_test_sweeper.go`, `internal/sweep/role_resource_test_sweeper.go`, `internal/sweep/sweeper_utils.go`)
* Registered sweepers in the provider's test suite via `TestMain` in `internal/provider/armis_sweeper_test.go`.
* Updated `.github/workflows/test.yml` to install Task, run acceptance tests, and execute the sweeper (`task sweep`) as part of the CI pipeline, ensuring cleanup of dangling resources after tests.
* Added a new `sweep` task in `Taskfile.yml` to invoke sweeper tests with a warning about resource destruction.
* Standardized test resource names to "test" (instead of "Test User" or "test-role") in `user_resource_test.go` and `role_resource_test.go` for alignment with sweeper logic.
* Added a new error (`ErrGetURL`) to `internal/armis/errors.go` for missing API URL, improving sweeper client setup diagnostics

> [!NOTE]
> Additional logic is needed to implement test sweepers for the policy resources
## why

- This introduces a sweeping mechanism to clean up test resources in the Armis Terraform provider. It adds new sweeper utility functions, integrates them into the test workflow, and updates acceptance test configurations
- This helps ensure that test environments remain clean and prevent resource leaks after running tests

## references

- [Reference Provider](https://github.com/honeycombio/terraform-provider-honeycombio/blob/9aeca6654f6b7e9ef80ee17baacff655ac781cd9/.github/workflows/ci.yaml)
