### PR TITLE
feat: add import support for policy resources

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -17,6 +17,9 @@ Provides an Armis policy
 ## Example Usage
 
 ```terraform
+# Import an existing policy using its ID:
+# terraform import armis_policy.example_policy 123
+
 resource "armis_policy" "example_policy" {
   name                = "BMS Security Alert Policy"
   description         = "This is an example security policy with all options."

--- a/examples/resources/armis_policy/resource.tf
+++ b/examples/resources/armis_policy/resource.tf
@@ -1,3 +1,6 @@
+# Import an existing policy using its ID:
+# terraform import armis_policy.example_policy 123
+
 resource "armis_policy" "example_policy" {
   name                = "BMS Security Alert Policy"
   description         = "This is an example security policy with all options."

--- a/internal/provider/policy_resource.go
+++ b/internal/provider/policy_resource.go
@@ -14,6 +14,7 @@ import (
 	u "github.com/1898andCo/terraform-provider-armis-centrix/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -27,8 +28,9 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource              = &policyResource{}
-	_ resource.ResourceWithConfigure = &policyResource{}
+	_ resource.Resource                = &policyResource{}
+	_ resource.ResourceWithConfigure   = &policyResource{}
+	_ resource.ResourceWithImportState = &policyResource{}
 )
 
 type policyResource struct {
@@ -312,4 +314,21 @@ func (r *policyResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if !deleteResp {
 		resp.Diagnostics.AddError("Error deleting policy", "Delete operation was not successful")
 	}
+}
+
+// ImportState imports a policy resource by ID.
+func (r *policyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// The ID provided in the import command will be the policy ID
+	policyID := req.ID
+
+	if policyID == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			"Policy ID cannot be empty. Please provide a valid policy ID.",
+		)
+		return
+	}
+
+	// Set the ID in the state so the Read method can fetch the policy details
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), policyID)...)
 }

--- a/internal/provider/policy_resource_test.go
+++ b/internal/provider/policy_resource_test.go
@@ -34,6 +34,11 @@ func TestAcc_PolicyResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rules.and.0", "protocol:BMS"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -71,3 +76,6 @@ resource "armis_policy" "test" {
 }
 `
 }
+
+// Note: Unit tests for ImportState require proper Terraform framework setup
+// The acceptance test above includes import testing which is the standard approach

--- a/internal/utils/model_policies.go
+++ b/internal/utils/model_policies.go
@@ -15,7 +15,7 @@ type PolicyResourceModel struct {
 	MitreAttackLabels types.List   `tfsdk:"mitre_attack_labels"`
 	RuleType          types.String `tfsdk:"rule_type"`
 	Actions           types.List   `tfsdk:"actions"`
-	Rules             RulesModel   `tfsdk:"rules"`
+	Rules             types.Object `tfsdk:"rules"`
 }
 
 // ActionModel maps the action schema data.


### PR DESCRIPTION
## What
- Add ImportState functionality to armis_policy resource to allow importing existing policies by their ID
- Enable users to bring existing Armis policies under Terraform management
- Update documentation and examples with import usage

## Why
- Implement ResourceWithImportState interface for policy resource
- Add import validation with proper error handling for empty IDs
- Update acceptance tests to include import verification
- Add import documentation in both docs and examples
