### PR TITLE
refactor(role): remove suppress permission from manage

### DIFF
--- a/armis/model_roles.go
+++ b/armis/model_roles.go
@@ -73,7 +73,6 @@ type Alert struct {
 type Manage struct {
 	All              bool       `json:"all,omitempty"`
 	Resolve          Permission `json:"resolve,omitempty"`
-	Suppress         Permission `json:"suppress,omitempty"`
 	WhitelistDevices Permission `json:"whitelistDevices,omitempty"`
 }
 

--- a/armis/roles_test.go
+++ b/armis/roles_test.go
@@ -37,7 +37,6 @@ func TestCreatingRole(t *testing.T) {
 				Manage: Manage{
 					All:              true,
 					Resolve:          Permission{All: true},
-					Suppress:         Permission{All: true},
 					WhitelistDevices: Permission{All: true},
 				},
 				Read: Permission{All: true},

--- a/docs/data-sources/role.md
+++ b/docs/data-sources/role.md
@@ -101,7 +101,6 @@ Read-Only:
 
 - `all` (Boolean) Indicates if all alert management permissions are enabled.
 - `resolve` (Boolean) Permission to resolve alerts.
-- `suppress` (Boolean) Permission to suppress alerts.
 - `whitelist_devices` (Boolean) Permission to whitelist devices in alerts.
 
 

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -41,7 +41,6 @@ resource "armis_role" "auditor" {
       manage = {
         all               = false
         resolve           = false
-        suppress          = false
         whitelist_devices = false
       }
     }
@@ -297,7 +296,6 @@ Optional:
 
 - `all` (Boolean) Indicates if all alert management permissions are enabled.
 - `resolve` (Boolean) Permission to resolve alerts.
-- `suppress` (Boolean) Permission to suppress alerts.
 - `whitelist_devices` (Boolean) Permission to whitelist devices in alerts.
 
 

--- a/examples/resources/armis_role/resource.tf
+++ b/examples/resources/armis_role/resource.tf
@@ -26,7 +26,6 @@ resource "armis_role" "auditor" {
       manage = {
         all               = false
         resolve           = false
-        suppress          = false
         whitelist_devices = false
       }
     }

--- a/internal/provider/role_data_source.go
+++ b/internal/provider/role_data_source.go
@@ -152,10 +152,6 @@ func (d *rolesDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: "Permission to resolve alerts.",
 										Computed:    true,
 									},
-									"suppress": schema.BoolAttribute{
-										Description: "Permission to suppress alerts.",
-										Computed:    true,
-									},
 									"whitelist_devices": schema.BoolAttribute{
 										Description: "Permission to whitelist devices in alerts.",
 										Computed:    true,

--- a/internal/provider/role_data_source_test.go
+++ b/internal/provider/role_data_source_test.go
@@ -33,7 +33,6 @@ func TestAcc_RoleDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.all"),
 					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.manage.all"),
 					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.manage.resolve"),
-					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.manage.suppress"),
 					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.manage.whitelist_devices"),
 					resource.TestCheckResourceAttrSet("data.armis_role.test", "permissions.alert.read"),
 				),

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -155,10 +155,6 @@ func (r *roleResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 										Description: "Permission to resolve alerts.",
 										Optional:    true,
 									},
-									"suppress": schema.BoolAttribute{
-										Description: "Permission to suppress alerts.",
-										Optional:    true,
-									},
 									"whitelist_devices": schema.BoolAttribute{
 										Description: "Permission to whitelist devices in alerts.",
 										Optional:    true,

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -41,7 +41,6 @@ func TestAcc_RoleResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "permissions.alert.read", "true"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.alert.manage.all", "false"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.alert.manage.resolve", "true"),
-					resource.TestCheckResourceAttr(resourceName, "permissions.alert.manage.suppress", "false"),
 					resource.TestCheckResourceAttr(resourceName, "permissions.alert.manage.whitelist_devices", "true"),
 
 					resource.TestCheckResourceAttr(resourceName, "permissions.device.all", "false"),
@@ -109,7 +108,6 @@ resource "armis_role" "test" {
       manage = {
         all               = false
         resolve           = true
-        suppress          = false
         whitelist_devices = true
       }
     }

--- a/internal/utils/model_roles.go
+++ b/internal/utils/model_roles.go
@@ -70,7 +70,6 @@ type AlertModel struct {
 type ManageAlertsModel struct {
 	All              types.Bool `tfsdk:"all"`
 	Resolve          types.Bool `tfsdk:"resolve"`
-	Suppress         types.Bool `tfsdk:"suppress"`
 	WhitelistDevices types.Bool `tfsdk:"whitelist_devices"`
 }
 

--- a/internal/utils/roles_utils.go
+++ b/internal/utils/roles_utils.go
@@ -56,9 +56,6 @@ func BuildRoleRequest(role RoleResourceModel) armis.RoleSettings {
 					Resolve: armis.Permission{
 						All: role.Permissions.Alert.Manage.Resolve.ValueBool(),
 					},
-					Suppress: armis.Permission{
-						All: role.Permissions.Alert.Manage.Suppress.ValueBool(),
-					},
 					WhitelistDevices: armis.Permission{
 						All: role.Permissions.Alert.Manage.WhitelistDevices.ValueBool(),
 					},
@@ -378,7 +375,6 @@ func BuildRoleResourceModel(role *armis.RoleSettings, model RoleResourceModel) R
 	// Alert Manage Permissions
 	result.Permissions.Alert.Manage.All = types.BoolValue(role.Permissions.Alert.Manage.All)
 	result.Permissions.Alert.Manage.Resolve = types.BoolValue(role.Permissions.Alert.Manage.Resolve.All)
-	result.Permissions.Alert.Manage.Suppress = types.BoolValue(role.Permissions.Alert.Manage.Suppress.All)
 	result.Permissions.Alert.Manage.WhitelistDevices = types.BoolValue(role.Permissions.Alert.Manage.WhitelistDevices.All)
 
 	// Device Permissions
@@ -555,7 +551,6 @@ func BuildRoleDataSourceModel(role *armis.RoleSettings) RoleDataSourceModel {
 				Manage: &ManageAlertsModel{
 					All:              types.BoolValue(role.Permissions.Alert.Manage.All),
 					Resolve:          types.BoolValue(role.Permissions.Alert.Manage.Resolve.All),
-					Suppress:         types.BoolValue(role.Permissions.Alert.Manage.Suppress.All),
 					WhitelistDevices: types.BoolValue(role.Permissions.Alert.Manage.WhitelistDevices.All),
 				},
 				Read: types.BoolValue(role.Permissions.Alert.Read.All),


### PR DESCRIPTION

## why

- The Armis API no longer supports the `suppress` permission for alerts

<img width="251" height="181" alt="image" src="https://github.com/user-attachments/assets/846bb5f9-886a-49c2-b671-d73fc63b307c" />

## what

- This removes the "suppress" alert management permission from the codebase, including its schema definitions, documentation, test cases, and utility functions. The change affects both the resource and data source representations of roles, as well as related documentation and examples.

**Removal of "suppress" alert management permission:**

*Schema and Model Updates:*
- Removed the `Suppress` field from the `Manage` struct in `armis/model_roles.go` and `ManageAlertsModel` in `internal/utils/model_roles.go`. [[1]](diffhunk://#diff-b94a538d0fd5d4e60419adeec9e8581caad07abc34a338c367ebee7b633bea44L76) [[2]](diffhunk://#diff-8d4e6204a1365484ee2feca031dc150ab3d8a54d6fcf12b64d078158ca55b929L73)
- Deleted the "suppress" attribute from the Terraform provider schemas in `internal/provider/role_resource.go` and `internal/provider/role_data_source.go`. [[1]](diffhunk://#diff-e1a140a60de11428c7904efeb759dfbf1f26df12e4b8710d228b3ef618df321cL158-L161) [[2]](diffhunk://#diff-255eda275b4612a6a4ac84edafeaf63a1330d69660ce383a83d374389c07ea6dL155-L158)

*Utility Function Updates:*
- Removed handling of the "suppress" permission from role building and mapping functions in `internal/utils/roles_utils.go`. [[1]](diffhunk://#diff-667bdb17d466811399f60d0af8c02b56876fd758f5fd9eca858049d08d883996L59-L61) [[2]](diffhunk://#diff-667bdb17d466811399f60d0af8c02b56876fd758f5fd9eca858049d08d883996L381) [[3]](diffhunk://#diff-667bdb17d466811399f60d0af8c02b56876fd758f5fd9eca858049d08d883996L558)

*Documentation and Example Updates:*
- Deleted references to the "suppress" permission from documentation files (`docs/resources/role.md`, `docs/data-sources/role.md`) and example Terraform configurations. [[1]](diffhunk://#diff-bc1daefb35267e062b3e1bcc6f18382c58dff44b030aee91bb67d9df136bef9fL44) [[2]](diffhunk://#diff-bc1daefb35267e062b3e1bcc6f18382c58dff44b030aee91bb67d9df136bef9fL300) [[3]](diffhunk://#diff-a101e1cff79e16f96a426c097cf04bcbc751edda7c75e675f29d6f8c1f387390L104) [[4]](diffhunk://#diff-a593bdf84ae1bbdd403f788a52ea4dd6a1b1aaf109e3d1723d5cc22c9efd1203L29)

*Test Updates:*
- Removed "suppress" permission checks and attributes from role-related tests in both acceptance and unit tests. [[1]](diffhunk://#diff-b20ad6337e0e48bb64b0f8803b257a8363d9fb2f1b3511c4e9c1c9ac21966e6bL40) [[2]](diffhunk://#diff-288469142bc97a540f3a8aea6842ac74707ade6bec38272813a91f5aa5b9c563L44) [[3]](diffhunk://#diff-288469142bc97a540f3a8aea6842ac74707ade6bec38272813a91f5aa5b9c563L112) [[4]](diffhunk://#diff-4cc09bfa62fbcb1b7bacc2addae5bbae09c607a981b4797d3b46640d43c8dc38L36)

This change simplifies the role management model by eliminating the unused or deprecated "suppress" permission throughout the provider.

