### PR TITLE
refactor: improve action model conversion logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 0.12 or [OpenTofu](https://opentofu.org/) >= 1.5
-- [Go](https://golang.org/doc/install) >= 1.22 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) >= 1.25 (to build the provider plugin)
 
 ## Authenticating to Armis Centrix
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/1898andCo/terraform-provider-armis-centrix
 
-go 1.23.0
-
-toolchain go1.24.0
+go 1.25
 
 require (
 	github.com/charmbracelet/log v0.4.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,8 +1,6 @@
 module tools
 
-go 1.23.7
-
-toolchain go1.24.0
+go 1.25
 
 require (
 	github.com/hashicorp/copywrite v0.22.0


### PR DESCRIPTION
## Why

- This updates the Go version requirements and refactors the policy action conversion utilities for improved clarity and maintainability. The most significant changes are the increase of the minimum Go version to 1.25 and a major refactor of the `ConvertListToActions` and `ConvertActionsToList` functions to modularize and clarify the conversion logic between Terraform types and internal models

## What

- Increased the minimum required Go version to 1.25 in `README.md`, `go.mod`, and `tools/go.mod`.
- Refactored `ConvertListToActions` in `policy_utils.go` to extract and modularize logic into helper functions: `extractActionModels`, `convertActionModel`, `paramsFromObject`, and `consolidationFromObject`. This improves readability, error handling, and maintainability.
- Improved the handling of null and unknown values in `ConvertActionsToList` for all fields, ensuring that only set values are included in the resulting Terraform objects. This results in more accurate and predictable conversions.
