### PR TITLE
feat(search): add AQL search API support

### DIFF
--- a/armis/errors.go
+++ b/armis/errors.go
@@ -38,4 +38,7 @@ var (
 	ErrRoleID       = errors.New("role ID cannot be empty")
 	ErrRoleName     = errors.New("role name cannot be empty")
 	ErrRoleNotFound = errors.New("role not found")
+
+	// Search errors.
+	ErrSearchAQL = errors.New("search AQL cannot be empty")
 )

--- a/armis/model_search.go
+++ b/armis/model_search.go
@@ -1,0 +1,47 @@
+package armis
+
+// SearchAPIResponse represents the response returned by the search endpoint.
+type SearchAPIResponse struct {
+	Data    SearchData `json:"data"`
+	Success bool       `json:"success"`
+}
+
+// SearchData contains pagination metadata and the list of search results.
+type SearchData struct {
+	Count   int            `json:"count"`
+	Next    *int           `json:"next"`
+	Prev    *int           `json:"prev"`
+	Results []SearchResult `json:"results"`
+	Total   int            `json:"total"`
+}
+
+// SearchResult represents a single search hit returned by Armis.
+type SearchResult struct {
+	ActivityUUIDs        []string         `json:"activityUUIDs,omitempty"`
+	AffectedDevicesCount int              `json:"affectedDevicesCount,omitempty"`
+	AlertID              int              `json:"alertId,omitempty"`
+	Classification       string           `json:"classification,omitempty"`
+	ConnectionIDs        []string         `json:"connectionIds,omitempty"`
+	Description          string           `json:"description,omitempty"`
+	DestinationEndpoints []SearchEndpoint `json:"destinationEndpoints,omitempty"`
+	DeviceIDs            []int            `json:"deviceIds,omitempty"`
+	LastAlertUpdateTime  string           `json:"lastAlertUpdateTime,omitempty"`
+	MitreAttackLabels    []string         `json:"mitreAttackLabels,omitempty"`
+	PolicyID             string           `json:"policyId,omitempty"`
+	PolicyLabels         []string         `json:"policyLabels,omitempty"`
+	PolicyTitle          string           `json:"policyTitle,omitempty"`
+	Severity             string           `json:"severity,omitempty"`
+	SourceEndpoints      []SearchEndpoint `json:"sourceEndpoints,omitempty"`
+	Status               string           `json:"status,omitempty"`
+	StatusChangeTime     string           `json:"statusChangeTime,omitempty"`
+	Time                 string           `json:"time,omitempty"`
+	Title                string           `json:"title,omitempty"`
+	Type                 string           `json:"type,omitempty"`
+}
+
+// SearchEndpoint represents an endpoint referenced in a search result.
+type SearchEndpoint struct {
+	ID   string `json:"id,omitempty"`
+	IP   string `json:"ip,omitempty"`
+	Name string `json:"name,omitempty"`
+}

--- a/armis/search.go
+++ b/armis/search.go
@@ -1,0 +1,47 @@
+package armis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// GetSearch executes an AQL search request. The `aql` parameter must be a valid
+// Armis Query Language string. The caller can control inclusion of sample
+// results and totals via the boolean flags.
+func (c *Client) GetSearch(ctx context.Context, aql string, includeSample, includeTotal bool) (SearchData, error) {
+	if strings.TrimSpace(aql) == "" {
+		return SearchData{}, fmt.Errorf("%w", ErrSearchAQL)
+	}
+
+	params := url.Values{}
+	params.Set("aql", aql)
+	params.Set("includeSample", strconv.FormatBool(includeSample))
+	params.Set("includeTotal", strconv.FormatBool(includeTotal))
+
+	encodedParams := params.Encode()
+
+	req, err := c.newRequest(ctx, "GET", fmt.Sprintf("/api/%s/search/?%s", c.apiVersion, encodedParams), nil)
+	if err != nil {
+		return SearchData{}, fmt.Errorf("failed to create request for GetSearch: %w", err)
+	}
+
+	res, err := c.doRequest(req)
+	if err != nil {
+		return SearchData{}, fmt.Errorf("failed to execute search: %w", err)
+	}
+
+	var response SearchAPIResponse
+	if err := json.Unmarshal(res, &response); err != nil {
+		return SearchData{}, fmt.Errorf("failed to parse search response: %w", err)
+	}
+
+	if !response.Success {
+		return SearchData{}, fmt.Errorf("%w: %+v", ErrHTTPResponse, response)
+	}
+
+	return response.Data, nil
+}

--- a/armis/search_test.go
+++ b/armis/search_test.go
@@ -1,0 +1,24 @@
+package armis
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGettingSearch(t *testing.T) {
+	t.Parallel()
+	client := integrationClient(t)
+
+	const aql = "in:alerts status:Open timeFrame:\"7 Days\""
+
+	res, err := client.GetSearch(context.Background(), aql, true, true)
+	if err != nil {
+		t.Fatalf("get search: %v", err)
+	}
+
+	prettyPrint(res)
+
+	if res.Total == 0 {
+		t.Logf("no results returned for AQL %q", aql)
+	}
+}


### PR DESCRIPTION
## what

- This adds support for performing AQL (Armis Query Language) searches to the codebase. It introduces new data models for search results, implements the `GetSearch` method to execute searches against the Armis API, and includes integration tests to verify search functionality. Additionally, a new error type is added for invalid or empty AQL queries.

* Added `GetSearch` method to the `Client` struct in `search.go`, allowing execution of AQL searches with options for including sample results and totals. The method handles request construction, response parsing, and error handling.
* Introduced new error type `ErrSearchAQL` for empty AQL query validation in `errors.go`.
* Created `model_search.go` with new types: `SearchAPIResponse`, `SearchData`, `SearchResult`, and `SearchEndpoint` to represent the structure of search responses and results from the Armis API.
* Added an integration test in `search_test.go` to verify `GetSearch` functionality, including result printing and basic validation.

## why

- Support Armis AQL searches in the Go SDK for tooling to use this capability

## references

- [Armis AQL](https://www.armis.com/blog/harnessing-the-power-of-the-armis-standard-query-asq-tool-part-1/)