### PR TITLE
ci(codeowners): migrate validate-codeowners to self-hosted runner (MSSCI-15692)

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate-codeowners:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Ubuntu, Common]
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Migrates `validate-codeowners.yml` from `ubuntu-latest` to `[self-hosted, Ubuntu, Common]`
- Part of org-wide runner migration effort (MSSCI-15689)

## Test plan

- [ ] Workflow triggers on PR and passes on self-hosted runner

Refs: MSSCI-15692