### PR TITLE
Fix Terraform Provider Armis Centrix CodeQL Failures

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: 'go.mod'
+          cache: ${{ matrix.dependency-caching }}
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
@@ -49,11 +55,16 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
           #
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4
-
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
+
+      # Replace the default autobuild step with an explicit build so CodeQL
+      # can reliably compile and analyze all Go sources under main.go and
+      # internal/. This matches the `task build` target defined in Taskfile.yml.
+      - name: Build Go sources for CodeQL analysis
+        run: |
+          go mod download
+          go build -v ./...
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4


### PR DESCRIPTION
## what and why

This pull request updates the CodeQL workflow to improve Go project analysis by explicitly setting up the Go environment and replacing the default autobuild step with a custom build process. This ensures all Go sources are reliably compiled and analyzed during CodeQL scans.

**Improvements to CodeQL workflow for Go projects:**

* Added a step to set up the Go environment using `actions/setup-go`, configuring it to use the version specified in `go.mod` and enabling dependency caching.
* Replaced the default `autobuild` step with an explicit build step that runs `go mod download` and `go build -v ./...`, ensuring all Go sources are compiled and ready for CodeQL analysis.