### PR TITLE
chore(ci): migrate codeowners-validator to step-security maintained fork

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -18,8 +18,7 @@ jobs:
 
     - name: "Checkout source code at current commit"
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
-    - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f # v0.7.4
+    - uses: step-security/codeowners-validator@073378e2c16714d69ac00356acebdb7505d82c7e # v0.7.4
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -31,8 +30,7 @@ jobs:
         checks: "syntax,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.GITHUB_TOKEN }}"
-      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
-    - uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f # v0.7.4
+    - uses: step-security/codeowners-validator@073378e2c16714d69ac00356acebdb7505d82c7e # v0.7.4
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:


### PR DESCRIPTION
## Summary
- Replace abandoned `mszostok/codeowners-validator` with step-security's maintained fork at the same `v0.7.4` release (SHA `073378e2`)
- Remove obsolete pinning-rationale comments referencing mszostok issue #173

## Why
`mszostok/codeowners-validator` is no longer maintained upstream. step-security maintains a security-hardened fork that preserves the same v0.7.4 interface, so this is a drop-in replacement. Tracked in MSSCI-17279.

## Test plan
- [ ] CI runs the renamed validator and passes on this PR