### PR TITLE
MSSCI-17171: switch step-security egress-policy to block on safe jobs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -114,6 +114,7 @@ jobs:
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443
+            golangci-lint.run:443
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,10 +32,24 @@ jobs:
             dependency-caching: true
 
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            archive.ubuntu.com:80
+            archive.ubuntu.com:443
+            security.ubuntu.com:80
+            security.ubuntu.com:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -86,10 +100,20 @@ jobs:
       # allow write access to security events to allow the action to upload SARIF files.
       security-events: write
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -27,10 +27,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -46,10 +56,21 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            releases.hashicorp.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -77,10 +98,20 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -21,6 +21,11 @@ concurrency:
   group: armis-provider-tests
   cancel-in-progress: false
 
+# Suppress HashiCorp version-check telemetry across all jobs that run Terraform.
+# Avoids needing to allowlist checkpoint-api.hashicorp.com.
+env:
+  CHECKPOINT_DISABLE: "1"
+
 jobs:
   build:
     name: Build
@@ -71,6 +76,7 @@ jobs:
             sum.golang.org:443
             storage.googleapis.com:443
             releases.hashicorp.com:443
+            registry.terraform.io:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -143,10 +149,24 @@ jobs:
           - '1.12.2'
           - '1.14.3'
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            releases.hashicorp.com:443
+            registry.terraform.io:443
+            *.s3.amazonaws.com:443
+            *.armis.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -186,10 +206,21 @@ jobs:
     if: always()
     timeout-minutes: 10
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
+            *.armis.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,20 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            codeload.github.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            storage.googleapis.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -11,10 +11,17 @@ jobs:
   validate-codeowners:
     runs-on: ubuntu-latest
     steps:
-    - name: Harden the runner (Audit all outbound calls)
+    - name: Harden the runner (Block egress)
       uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
       with:
-        egress-policy: audit
+        egress-policy: block
+        allowed-endpoints: >
+          api.github.com:443
+          github.com:443
+          objects.githubusercontent.com:443
+          codeload.github.com:443
+          raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
 
     - name: "Checkout source code at current commit"
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## what

- Move harden-runner from advisory `audit` to enforcing `block` on jobs whose outbound calls are well-known and limited to GitHub + Go module proxy + Hashicorp + Ubuntu apt.
- Keep `audit` mode on jobs that hit the ARMIS API (`provider-tests`, `cleanup` in `provider-tests.yml`, and `sweep` in `sweep.yml`) until the runtime ARMIS host is known and can be added to the allowlist.

## why

- Aligns the provider repo with the security baseline being rolled out across other 1898 repos (audit-only mode silently logs but never blocks).
- The Go-only / GitHub-only jobs have a small, well-defined set of endpoints. Locking them down catches anything unexpected immediately.
- The ARMIS-touching jobs are deferred because the API host comes from a runtime secret (`ARMIS_API_URL`) — converting them to block now would break tests until the right hostname is added.

## what changed

| Workflow / Job | Mode | Allowed endpoints |
|---|---|---|
| `codeql.yml/analyze` | block | GitHub baseline + Go module proxy + Ubuntu apt |
| `codeql.yml/lint-golangci` | block | GitHub baseline + Go module proxy |
| `provider-tests.yml/build` | block | GitHub baseline + Go module proxy |
| `provider-tests.yml/docs` | block | GitHub baseline + Go module proxy + `releases.hashicorp.com` |
| `provider-tests.yml/unit-tests` | block | GitHub baseline + Go module proxy |
| `provider-tests.yml/provider-tests` | **audit** (deferred) | n/a |
| `provider-tests.yml/cleanup` | **audit** (deferred) | n/a |
| `release.yml/goreleaser` | block | GitHub baseline + Go module proxy |
| `sweep.yml/sweep` | **audit** (deferred) | n/a |
| `validate-codeowners.yml/validate-codeowners` | block | GitHub baseline |

### Endpoint sets in detail

**GitHub baseline (every block-mode job):**

| Endpoint | Reason |
|---|---|
| `api.github.com:443` | GitHub REST API (action metadata, gh CLI) |
| `github.com:443` | \`git clone\` / \`fetch\` over HTTPS, action \`uses:\` ref resolution |
| `objects.githubusercontent.com:443` | GitHub-hosted blob/asset storage for action archives |
| `codeload.github.com:443` | Tarball/zip downloads of action source |
| `raw.githubusercontent.com:443` | Raw file fetches |
| `release-assets.githubusercontent.com:443` | Binary release-asset downloads |

**Go module proxy (jobs that run \`go mod download\`/\`go build\`/\`go test\`):**

| Endpoint | Reason |
|---|---|
| `proxy.golang.org:443` | Default GOPROXY — fetches module zips and metadata |
| `sum.golang.org:443` | Checksum DB for module verification |
| `storage.googleapis.com:443` | Backing GCS host for proxy.golang.org module artefacts |

**Hashicorp (only `provider-tests.yml/docs`):**

| Endpoint | Reason |
|---|---|
| `releases.hashicorp.com:443` | `step-security/setup-terraform` downloads the Terraform binary from here |

**Ubuntu apt (only `codeql.yml/analyze`):**

| Endpoint | Reason |
|---|---|
| `archive.ubuntu.com:80` / `:443` | Main Ubuntu package archive |
| `security.ubuntu.com:80` / `:443` | Ubuntu security updates archive |

Step labels were also updated from `Harden the runner (Audit all outbound calls)` → `Harden the runner (Block egress)` on jobs that flipped to block mode.

## testing

- [x] YAML syntactically valid (round-tripped through Edit).
- [ ] First workflow run on this PR is the real verification — if any job fails on a blocked endpoint, harden-runner output will name it and it can be added in a follow-up.
- [ ] Follow-up PR: convert the three deferred jobs (provider-tests, cleanup, sweep) to block once the ARMIS API host is captured from harden-runner audit logs.

## references

- Refs: MSSCI-17171
- Pattern reference: axiathon PR 1898andCo/axiathon#101 (same egress-policy switch).