### PR TITLE
MSSCI-17632 chore(ci): migrate golangci-lint-action to step-security fork

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -122,7 +122,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        uses: step-security/golangci-lint-action@1797facf9ea427614d729a4e9cab0fae1a7852d9 # v9.2.0
         id: golangci
         with:
           version: v2.4


### PR DESCRIPTION
## Migration

Replace `golangci/golangci-lint-action@v9` with `step-security/golangci-lint-action@v9.2.0` in `.github/workflows/codeql.yml`.

```diff
- uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+ uses: step-security/golangci-lint-action@1797facf9ea427614d729a4e9cab0fae1a7852d9 # v9.2.0
```

## Why

step-security publishes hardened forks of widely-used actions with signed releases and responds to upstream abandonment.

## Risk

Low — same major version (v9 → v9.2.0), no breaking API or config changes expected.

## Refs

- Parent epic: [MSSCI-17289](https://1898andco.atlassian.net/browse/MSSCI-17289)
- Ticket: [MSSCI-17632](https://1898andco.atlassian.net/browse/MSSCI-17632)
