### PR TITLE
MSSCI-17648 chore(ci): migrate goreleaser-action to step-security fork

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+        uses: step-security/goreleaser-action@1472c46ac6e641f2b929f1a893354288b3a6b6b6 # v7.2.1
         with:
           args: release --clean
         env:


### PR DESCRIPTION
## Migration

Replace `goreleaser/goreleaser-action@v6.4.0` with `step-security/goreleaser-action@v7.2.1` in `.github/workflows/release.yml`.

```diff
- uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
+ uses: step-security/goreleaser-action@1472c46ac6e641f2b929f1a893354288b3a6b6b6 # v7.2.1
```

## Why

step-security publishes hardened forks of widely-used actions with signed releases and responds to upstream abandonment.

## Risk

**Major version bump (v6 → v7).** goreleaser-action v7 expects GoReleaser v2.x by default. If this project's release pipeline relies on goreleaser v1.x semantics, the job may need a `version` input or a `.goreleaser.yaml` schema update. CI on the next tagged release will surface any incompatibility.

## Refs

- Parent epic: [MSSCI-17289](https://1898andco.atlassian.net/browse/MSSCI-17289)
- Ticket: [MSSCI-17648](https://1898andco.atlassian.net/browse/MSSCI-17648)
