### PR TITLE
MSSCI-17171 add allowed-endpoints from stepsecurity insights data

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,18 +38,19 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
+            archive.ubuntu.com:443
+            archive.ubuntu.com:80
             codeload.github.com:443
+            github.com:443
+            golangci-lint.run:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
-            storage.googleapis.com:443
-            archive.ubuntu.com:80
-            archive.ubuntu.com:443
-            security.ubuntu.com:80
             security.ubuntu.com:443
+            security.ubuntu.com:80
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/provider-tests.yml
+++ b/.github/workflows/provider-tests.yml
@@ -38,14 +38,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            codeload.github.com:443
+            proxy.golang.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
             storage.googleapis.com:443
+            sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -67,16 +68,17 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            codeload.github.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
             proxy.golang.org:443
-            sum.golang.org:443
-            storage.googleapis.com:443
-            releases.hashicorp.com:443
+            raw.githubusercontent.com:443
             registry.terraform.io:443
+            release-assets.githubusercontent.com:443
+            releases.hashicorp.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -110,14 +112,15 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            codeload.github.com:443
+            proxy.golang.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
             storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -154,19 +157,20 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            *.armis.com:443
+            *.s3.amazonaws.com:443
             api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            codeload.github.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
             proxy.golang.org:443
-            sum.golang.org:443
-            storage.googleapis.com:443
-            releases.hashicorp.com:443
+            raw.githubusercontent.com:443
             registry.terraform.io:443
-            *.s3.amazonaws.com:443
-            *.armis.com:443
+            release-assets.githubusercontent.com:443
+            releases.hashicorp.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -211,16 +215,17 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: >
+            *.armis.com:443
             api.github.com:443
+            checkpoint-api.hashicorp.com:443
+            codeload.github.com:443
             github.com:443
             objects.githubusercontent.com:443
-            codeload.github.com:443
+            proxy.golang.org:443
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
             storage.googleapis.com:443
-            *.armis.com:443
+            sum.golang.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -19,10 +19,19 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner (Audit all outbound calls)
+      - name: Harden the runner (Block egress)
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            codeload.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            release-assets.githubusercontent.com:443
+            storage.googleapis.com:443
+            sum.golang.org:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
Add observed endpoints to Harden-Runner block-mode `allowed-endpoints` lists, based on StepSecurity insights data (anomalous endpoint sweep, 2026-06-19).

## Changes
- `.github/workflows/codeql.yml`: golangci-lint.run:443 (1/2 blocks)
- `.github/workflows/provider-tests.yml`: checkpoint-api.hashicorp.com:443 (5/5 blocks)

## Jira
[MSSCI-17171](https://1898andco.atlassian.net/browse/MSSCI-17171)